### PR TITLE
Fix mute status on Big Sur

### DIFF
--- a/Sources/volume-service/CTSVolumeService.m
+++ b/Sources/volume-service/CTSVolumeService.m
@@ -99,7 +99,7 @@ static NSTimeInterval const kUpdateDebounceTimeInterval = 0.02;
         .mElement = kAudioObjectPropertyElementMaster,
         .mSelector = kAudioDevicePropertyMute,
     };
-    BOOL isMuted;
+    UInt32 isMuted;
     UInt32 isMutedSize = sizeof(isMuted);
 
     AudioHardwareServiceGetPropertyData(outputDeviceID,
@@ -108,7 +108,7 @@ static NSTimeInterval const kUpdateDebounceTimeInterval = 0.02;
                                         NULL,
                                         &isMutedSize,
                                         &isMuted);
-    return isMuted;
+    return (isMuted > 0);
 }
 
 - (int)outputVolume:(AudioDeviceID const)outputDeviceID


### PR DESCRIPTION
Hey Andrew,

Your btt automation services have worked really well for me, so thanks for making them available.

I recently switched to Big Sur and found that while the volume was reflected in the control strip icon, mute status was always True. 

It seems that AudioHardwareServiceGetPropertyData (and AudioObjectGetPropertyData) need a uint32 rather than a bool ([test script](https://gist.github.com/aaronkollasch/7adc237aa6107fab3e25572473e02d81) in swift), and a couple lines fixed the issue.

This change may not be backwards compatible but I'm posting it just in case anyone else has the same issue.

Aaron